### PR TITLE
Assorted updates to publish and retrieve

### DIFF
--- a/roles/resource_manager/includes/publish.yaml
+++ b/roles/resource_manager/includes/publish.yaml
@@ -9,6 +9,6 @@
   ansible.scm.git_publish:
     path: "{{ resource_manager_repository['path'] }}"
     token: "{{ data_store['scm']['origin']['token'] }}"
-    user: "{{ data_store['scm']['origin']['user'] }}"
+    user: "{{ data_store['scm']['origin']['user'] | d({}) }}"
     timeout: 120
   when: data_store['scm']['origin']['token'] is defined

--- a/roles/resource_manager/includes/retrieve.yaml
+++ b/roles/resource_manager/includes/retrieve.yaml
@@ -1,32 +1,16 @@
 ---
-- name: Perform retrieve with provided credentials
-  when: data_store.scm.origin.token is defined
-  block:
-    - name: Retrieve the host vars with provided token access
-      ansible.scm.git_retrieve:
-        origin:
-          url: "{{ data_store['scm']['origin']['url'] }}"
-          token: "{{ data_store['scm']['origin']['token'] }}"
-        parent_directory: "{{ data_store.scm.parent_directory | default(resource_manager_inventory_directory) }}"
-      register: resource_manager_result
+- name: Retrieve the host vars with token access (if provided)
+  ansible.scm.git_retrieve:
+    origin:
+      url: "{{ data_store['scm']['origin']['url'] }}"
+      token: "{{ data_store['scm']['origin']['token'] | d(None) }}"
+    parent_directory: "{{ data_store.scm.parent_directory | default(resource_manager_inventory_directory) }}"
+  changed_when: false
+  register: resource_manager_result
 
-    - name: Update data store path
-      ansible.builtin.set_fact:
-        resource_manager_repository: "{{ resource_manager_result }}"
-
-- name: Perform retrieve with default settings
-  when: data_store.scm.origin.token is undefined
-  block:
-    - name: Retrieve host vars with default access
-      ansible.scm.git_retrieve:
-        origin:
-          url: "{{ data_store['scm']['origin']['url'] }}"
-        parent_directory: "{{ data_store.scm.parent_directory | default(resource_manager_inventory_directory) }}"
-      register: resource_manager_result
-
-    - name: Update data store path
-      ansible.builtin.set_fact:
-        resource_manager_repository: "{{ resource_manager_result }}"
+- name: Update data store path
+  ansible.builtin.set_fact:
+    resource_manager_repository: "{{ resource_manager_result }}"
 
 - name: Update Inventory Path
   ansible.builtin.set_fact:


### PR DESCRIPTION
- When using a Personal Access Token, `user` is not mandatory.
- We can use `default(None)` instead of having two separate tasks for retrieve in case of token not provided.